### PR TITLE
use sub directory(asset sharing)

### DIFF
--- a/subdir/PITCHME.md
+++ b/subdir/PITCHME.md
@@ -4,6 +4,14 @@ Learn GitPitch
 
 ---
 
-### OK
+### See
 
-* [Asset Sharing ・ gitpitch/gitpitch Wiki https://github.com/gitpitch/gitpitch/wiki/Asset-Sharing]
+* サブディレクトリで使う（１つのリポジトリに複数のPITCHME.md）
+
+    * [Asset Sharing ・ gitpitch/gitpitch Wiki https://github.com/gitpitch/gitpitch/wiki/Asset-Sharing]
+
+* feature/xxx のようにブランチをスラッシュで区切る場合
+
+    * [Support for branches with odd characters in names ・ Issue #99 ・ gitpitch/gitpitch https://github.com/gitpitch/gitpitch/issues/99]
+    * 要は / を ~ にする
+

--- a/subdir/PITCHME.md
+++ b/subdir/PITCHME.md
@@ -1,0 +1,9 @@
+### Sub Directory Test
+
+Learn GitPitch
+
+---
+
+### OK
+
+* [Asset Sharing ・ gitpitch/gitpitch Wiki https://github.com/gitpitch/gitpitch/wiki/Asset-Sharing]

--- a/subdir/PITCHME.md
+++ b/subdir/PITCHME.md
@@ -8,10 +8,10 @@ Learn GitPitch
 
 * サブディレクトリで使う（１つのリポジトリに複数のPITCHME.md）
 
-    * [Asset Sharing ・ gitpitch/gitpitch Wiki https://github.com/gitpitch/gitpitch/wiki/Asset-Sharing]
+    * [Asset Sharing ・ gitpitch/gitpitch Wiki](https://github.com/gitpitch/gitpitch/wiki/Asset-Sharing)
 
 * feature/xxx のようにブランチをスラッシュで区切る場合
 
-    * [Support for branches with odd characters in names ・ Issue #99 ・ gitpitch/gitpitch https://github.com/gitpitch/gitpitch/issues/99]
+    * [Support for branches with odd characters in names ・ Issue #99 ・ gitpitch/gitpitch](https://github.com/gitpitch/gitpitch/issues/99)
     * 要は / を ~ にする
 

--- a/subdir/README.md
+++ b/subdir/README.md
@@ -1,0 +1,3 @@
+# Sub directory
+
+[![GitPitch](https://gitpitch.com/assets/badge.svg)](https://gitpitch.com/officel/aboutme/master?grs=github&t=moon&p=subdir)

--- a/subdir/README.md
+++ b/subdir/README.md
@@ -1,3 +1,6 @@
 # Sub directory
 
 [![GitPitch](https://gitpitch.com/assets/badge.svg)](https://gitpitch.com/officel/aboutme/master?grs=github&t=moon&p=subdir)
+
+
+[![GitPitch branch access](https://gitpitch.com/assets/badge.svg)](https://gitpitch.com/officel/aboutme/feature~subdir?grs=github&t=moon&p=subdir)


### PR DESCRIPTION
元はアセットの共有らしい。
１つのリポジトリで複数のスライドを公開することができる。
ついでに feature/xxx のようなブランチを切った場合にどのようにアクセスするか（/を~に変える）も発見したので置いておく。現時点ではドキュメントのwikiには記載されていないみたい。